### PR TITLE
Preserve reference to the original exception when casting to an RPC exception

### DIFF
--- a/Request/RpcRequestHandler.php
+++ b/Request/RpcRequestHandler.php
@@ -93,7 +93,7 @@ class RpcRequestHandler
             return $e;
         }
 
-        $rpcException = new RpcApplicationException($e->getMessage(), $e->getCode());
+        $rpcException = new RpcApplicationException($e->getMessage(), $e->getCode(), $e);
 
         if ($e instanceof RpcDataExceptionInterface) {
             $rpcException->setData($e->getData());


### PR DESCRIPTION
### Problem

Currently, when we catch all exceptions and convert them to RpcApplicationException in castToRpcException method, we lose essential context information with low-level exceptions. This loss of context makes it challenging to adequately log these exceptions or send them to Sentry for detailed analysis.

### Solution

Pass the original exception as $previous to the RpcApplicationException constructor, allowing us to access it later in the `nanofelis_json_rpc.before_response` event subscriber.